### PR TITLE
fix(deps): bump secrets manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You need the following permissions to run this module.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.70.0, <2.0.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.76.0, <2.0.0 |
 
 ### Modules
 

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -22,7 +22,7 @@ module "resource_group" {
 module "secrets_manager" {
   count                = var.existing_sm_instance_guid != null ? 0 : 1
   source               = "terraform-ibm-modules/secrets-manager/ibm"
-  version              = "1.24.3"
+  version              = "1.25.1"
   secrets_manager_name = "${var.prefix}-sm-instance"
   sm_service_plan      = var.sm_service_plan
   region               = local.sm_region

--- a/examples/basic/version.tf
+++ b/examples/basic/version.tf
@@ -4,7 +4,7 @@ terraform {
     # Pin to the lowest provider version of the range defined in the main module to ensure lowest version still works
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.70.0"
+      version = "1.76.0"
     }
   }
 }

--- a/examples/private/main.tf
+++ b/examples/private/main.tf
@@ -29,7 +29,7 @@ locals {
 
 module "secrets_manager" {
   source                   = "terraform-ibm-modules/secrets-manager/ibm"
-  version                  = "1.24.3"
+  version                  = "1.25.1"
   existing_sm_instance_crn = var.existing_sm_instance_crn
   resource_group_id        = module.resource_group.resource_group_id
   region                   = local.sm_region

--- a/examples/private/version.tf
+++ b/examples/private/version.tf
@@ -4,7 +4,7 @@ terraform {
     # Pin to the lowest provider version of the range defined in the main module to ensure lowest version still works
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.70.0"
+      version = "1.76.0"
     }
   }
 }

--- a/version.tf
+++ b/version.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.70.0, <2.0.0"
+      version = ">= 1.76.0, <2.0.0"
     }
   }
 }


### PR DESCRIPTION
### Description

Bump to secrets manager 1.25.1 with associate provider upgrade to 1.76.0 to get support for update authorization policy [6015](https://github.com/IBM-Cloud/terraform-provider-ibm/pull/6015)

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Bump to secrets manager 1.25.1 with associate provider upgrade to 1.76.0 to get support for update authorization policy [6015](https://github.com/IBM-Cloud/terraform-provider-ibm/pull/6015)

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
