### PR TITLE
fix: standardize resource_tags variable, update descriptions and add access tag validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,10 @@ You need the following permissions to run this module.
 |------|-------------|------|---------|:--------:|
 | <a name="input_access_group_name"></a> [access\_group\_name](#input\_access\_group\_name) | Name of the access group to create. If null is passed, the name will be set as '{secret\_group\_name}-access-group' | `string` | `null` | no |
 | <a name="input_access_group_roles"></a> [access\_group\_roles](#input\_access\_group\_roles) | Roles to be given to the created access group. | `list(string)` | `null` | no |
-| <a name="input_access_group_tags"></a> [access\_group\_tags](#input\_access\_group\_tags) | Tags that should be applied to the access group. Only applies if create\_access\_group is true. | `list(string)` | `[]` | no |
 | <a name="input_create_access_group"></a> [create\_access\_group](#input\_create\_access\_group) | Whether to create an access group for the secrets group. | `bool` | `false` | no |
 | <a name="input_endpoint_type"></a> [endpoint\_type](#input\_endpoint\_type) | The service endpoint type to communicate with the provided secrets manager instance. Possible values are `public` or `private` | `string` | `"public"` | no |
 | <a name="input_region"></a> [region](#input\_region) | Region which the Secret Manager is deployed. | `string` | n/a | yes |
+| <a name="input_resource_tags"></a> [resource\_tags](#input\_resource\_tags) | Add user resource tags to the Secret Group instance to organize, track, and manage costs. [Learn more](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#tag-types). | `list(string)` | `[]` | no |
 | <a name="input_secret_group_description"></a> [secret\_group\_description](#input\_secret\_group\_description) | Description of the Secret Group to be created. | `string` | n/a | yes |
 | <a name="input_secret_group_name"></a> [secret\_group\_name](#input\_secret\_group\_name) | Name of the Secret Group to be created. | `string` | n/a | yes |
 | <a name="input_secrets_manager_guid"></a> [secrets\_manager\_guid](#input\_secrets\_manager\_guid) | Instance ID of Secrets Manager instance in which the Secret will be added. | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ module "iam_access_groups" {
   policies = {
     sm_policy = {
       roles = var.access_group_roles
-      tags  = var.access_group_tags
+      tags  = var.resource_tags
       resources = [{
         service       = "secrets-manager"
         instance_id   = var.secrets_manager_guid

--- a/variables.tf
+++ b/variables.tf
@@ -50,10 +50,14 @@ variable "access_group_roles" {
     condition     = !var.create_access_group ? true : (var.access_group_roles == null ? false : length(var.access_group_roles) != 0)
   }
 }
-variable "access_group_tags" {
+variable "resource_tags" {
   type        = list(string)
-  description = "Tags that should be applied to the access group. Only applies if create_access_group is true."
+  description = "Add user resource tags to the Secret Group instance to organize, track, and manage costs. [Learn more](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#tag-types)."
   default     = []
+  validation {
+    condition     = alltrue([for tag in var.resource_tags : can(regex("^[A-Za-z0-9 _\\-.:](1, 128)$", tag))])
+    error_message = "Each resource tag must be 128 characters or less and may contain only A-Z, a-z, 0-9, spaces, underscore (_), hyphen (-), period (.), and colon (:)."
+  }
 }
 
 ##############################################################################


### PR DESCRIPTION
### Description

This PR updates:

- tags -> resource_tags
- resource_tags variable description and validation
- access_tags variable description
- Adds data block to ensure existing access_tags are being attached to the instance

---

### Release required?

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)
